### PR TITLE
small performance improvement

### DIFF
--- a/Pages/Index.razor
+++ b/Pages/Index.razor
@@ -378,10 +378,9 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        _context = await _canvasReference.CreateWebGLAsync();
-
         if (firstRender)
         {
+            _context = await _canvasReference.CreateWebGLAsync();
             shaderProgram = await InitShaderProgram();
             if (textureMapping)
             {
@@ -449,10 +448,9 @@
             }
         }
 
+        await _context.BeginBatchAsync();
         await _context.ClearColorAsync(0, 0, 0, 1);
         await _context.ClearDepthAsync(1.0f);
-
-        await _context.BeginBatchAsync();
         await _context.EnableAsync(EnableCap.DEPTH_TEST);
         await _context.DepthFuncAsync(CompareFunction.LEQUAL);
         await _context.ClearAsync(BufferBits.COLOR_BUFFER_BIT | BufferBits.DEPTH_BUFFER_BIT);

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -19,7 +19,7 @@
       "commandName": "Project",
       "dotnetRunMessages": "true",
       "launchBrowser": true,
-      "applicationUrl": "https://alans-macbook:5001;http://alans-macbook:5000",
+      "applicationUrl": "https://localhost:5001;http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }


### PR DESCRIPTION
create context one time only
put everything inside batch

This improves performance a little bit on my Macbook but not a lot - the JSInterop overhead is still about 50ms per frame, which is unacceptable. This project will likely be shelved, it was a good learning experience though! :)

Running in raw JS I can get 10x the performance, so Blazor doesn't look like a viable option right now. Unless I create something that can safely assume a high performance computer.